### PR TITLE
Allow TLS without client certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ config rule
   - `mqtt_protocol`: The MQTT protocol version to use. Must be either 3.1, 3.1.1, or 5.
   - `tls_version`: The TLS version to use. For OpenSSL >= 1.0.1, the available options are tlsv1.2, tlsv1.1, and tlsv1, with tlsv1.2 being the default. For OpenSSL < 1.0.1, the available options are tlsv1 and sslv3, with tlsv1 being the default.
   - `clean_session`: Whether to use a clean session for the MQTT connection. Must be either true or false.
-  - `ca_cert_path`: The path to the CA certificate file. If this option is not specified, the CA certificate will not be used.
-  - `cert_path`: The path to the certificate file. If this option is not specified, the certificate will not be used.
-  - `key_path`: The path to the key file. If this option is not specified, the key will not be used.
+  - `ca_cert_path`: The path to the CA certificate file. Set this to enable TLS with server certificate verification; it is required when using a client certificate.
+  - `cert_path`: Optional path to the client certificate file. It must be set together with `key_path`.
+  - `key_path`: Optional path to the client key file. It must be set together with `cert_path`.
   - `verify`: Whether to verify the server certificate. Should not be used in production.
   - `request_topic`: The topic used for receiving requests.
   - `response_topic`: The topic used to send responses.
@@ -188,9 +188,9 @@ config rule
   - `clean_session`: Whether to use a clean session for the MQTT connection. Must be either `true` or `false`.
   - `request_topic`: The topic used for receiving requests.
   - `response_topic`: The topic used to send responses.
-  - `ca_cert_path`: The path to the CA certificate file. If this option is not specified, the CA certificate will not be used.
-  - `cert_path`: The path to the certificate file. If this option is not specified, the certificate will not be used.
-  - `key_path`: The path to the key file. If this option is not specified, the key will not be used.
+  - `ca_cert_path`: The path to the CA certificate file. Set this to enable TLS with server certificate verification; it is required when using a client certificate.
+  - `cert_path`: Optional path to the client certificate file. It must be set together with `key_path`.
+  - `key_path`: Optional path to the client key file. It must be set together with `cert_path`.
 
 - `rule`: This section contains the settings for the Modbus communication filtering. It can appear multiple times in the config file. Each section has the following options:
   - `ip`: The IP address of the Modbus device, it must be an IPv6 address or an IPv4 address encoded in IPv6 format, and it must also include a subnet mask.

--- a/src/config_parser.c
+++ b/src/config_parser.c
@@ -672,9 +672,9 @@ validate_config(config_t *config) {
         return -6;
     }
 
-    // if one of the tls options is set, then all of them must be set
-    if (strlen(config->ca_cert_path) > 0 || strlen(config->cert_path) > 0 ||
-        strlen(config->key_path) > 0) {
+    // ca_cert_path is required whenever any TLS option is set.
+    // cert_path and key_path are optional but must be provided as a pair.
+    if (strlen(config->cert_path) > 0 || strlen(config->key_path) > 0) {
         if (strlen(config->ca_cert_path) == 0 ||
             strlen(config->cert_path) == 0 || strlen(config->key_path) == 0) {
             return -7;

--- a/test/test.c
+++ b/test/test.c
@@ -36,6 +36,7 @@ int main() {
     CU_add_test(suite3,
                 "test_validate_config_without_rules",
                 test_validate_config_without_rules);
+    CU_add_test(suite3, "test_validate_config_tls_options", test_validate_config_tls_options);
 
     CU_pSuite suite4 = CU_add_suite("Trim functions", NULL, NULL);
     CU_add_test(suite4, "test_trim_functions", test_trim_functions);

--- a/test/test.h
+++ b/test/test.h
@@ -25,6 +25,7 @@ void test_parse_option_range_ok(void);
 void test_config_file_parser_errors(void);
 void test_parse_option_range_errors(void);
 void test_validate_config_without_rules(void);
+void test_validate_config_tls_options(void);
 
 void test_trim_functions(void);
 

--- a/test/test_config.c
+++ b/test/test_config.c
@@ -215,6 +215,31 @@ test_validate_config_without_rules(void) {
 }
 
 void
+test_validate_config_tls_options(void) {
+    config_t config;
+    memset(&config, 0, sizeof(config));
+
+    strncpy(config.host, "127.0.0.1", sizeof(config.host) - 1);
+    config.port = 1883;
+    strncpy(config.client_id, "test-client", sizeof(config.client_id) - 1);
+    strncpy(config.request_topic, "request", sizeof(config.request_topic) - 1);
+    strncpy(config.response_topic, "response", sizeof(config.response_topic) - 1);
+
+    strncpy(config.ca_cert_path, "ca.crt", sizeof(config.ca_cert_path) - 1);
+    CU_ASSERT_EQUAL(validate_config(&config), 0);
+
+    memset(config.ca_cert_path, 0, sizeof(config.ca_cert_path));
+    strncpy(config.cert_path, "client.crt", sizeof(config.cert_path) - 1);
+    CU_ASSERT_EQUAL(validate_config(&config), -7);
+
+    strncpy(config.ca_cert_path, "ca.crt", sizeof(config.ca_cert_path) - 1);
+    CU_ASSERT_EQUAL(validate_config(&config), -7);
+
+    strncpy(config.key_path, "client.key", sizeof(config.key_path) - 1);
+    CU_ASSERT_EQUAL(validate_config(&config), 0);
+}
+
+void
 test_config_file_parser_errors(void) {
     // create a temporary file
     FILE *file = tmpfile();


### PR DESCRIPTION
## Summary
- Allow `ca_cert_path` to be set without `cert_path` and `key_path` for server-only TLS verification
- This enables a common use case: connecting to a TLS-secured MQTT broker with username/password authentication, without requiring mutual TLS (client certificates)
- `cert_path` and `key_path` remain required as a pair when either is set

## Background
The `validate_config()` function required all three TLS options (`ca_cert_path`, `cert_path`, `key_path`) if any one was set. However, the runtime code in `main.c` already correctly handles the case where only `ca_cert_path` is configured — it passes `NULL` for cert/key to `mosquitto_tls_set()`. The validation was unnecessarily blocking a working code path.

## Test plan
- [x] Tested with `ca_cert_path` only (server verification + username/password) — starts successfully
- [x] Verified existing mutual TLS config (all three options) still works
- [x] Confirmed missing `ca_cert_path` when `cert_path`/`key_path` are set still returns error -7

🤖 Generated with [Claude Code](https://claude.com/claude-code)